### PR TITLE
[Bug]Add sequence_parallel in layernorm init to enable 3D parallelism with DeepSpeed for non CUDA device.

### DIFF
--- a/megatron/model/__init__.py
+++ b/megatron/model/__init__.py
@@ -13,7 +13,7 @@ else:
         from .fused_rmsnorm import RMSNorm
     else:
         from .rmsnorm import RMSNorm
-    from torch.nn import LayerNorm
+    from .layernorm import SPLayerNorm as LayerNorm
 
 from .distributed import DistributedDataParallel
 from .bert_model import BertModel

--- a/megatron/model/layernorm.py
+++ b/megatron/model/layernorm.py
@@ -1,0 +1,10 @@
+import torch
+
+class SPLayerNorm(torch.nn.LayerNorm):
+    def __init__(self, normalized_shape, eps: float = 1e-5, sequence_parallel=False):
+        super(SPLayerNorm, self).__init__(normalized_shape, eps)
+        self.sequence_parallel = sequence_parallel
+        setattr(self.weight, 'sequence_parallel', self.sequence_parallel)
+
+    def forward(self, x):
+        return super(SPLayerNorm, self).forward(x)


### PR DESCRIPTION
When you running on non-CUDA device, for 3D parallelism with DeepSpeed you will got this error, can see below:
[rank19]:   File "/home/yisheng/anaconda3/envs/llm_pt_25/lib/python3.10/site-packages/deepspeed/runtime/pipe/module.py", line 214, in __init__
[rank19]:     self._build()
[rank19]:   File "/home/yisheng/anaconda3/envs/llm_pt_25/lib/python3.10/site-packages/deepspeed/runtime/pipe/module.py", line 270, in _build
[rank19]:     module = layer.build()
[rank19]:   File "/home/yisheng/anaconda3/envs/llm_pt_25/lib/python3.10/site-packages/deepspeed/runtime/pipe/module.py", line 74, in build
[rank19]:     return self.typename(*self.module_args, **self.module_kwargs)
[rank19]: TypeError: LayerNorm.__init__() got an unexpected keyword argument 'sequence_parallel'

cause for Megatron-DeepSpeed, sequence_parallel is added in Megatron-DeepSpeed for layernorm, for current implementation, non-CUDA device is using from torch.nn import LayerNorm for layernorm, there is no attr named sequence_parallel, will cause init error for non-CUDA device.
